### PR TITLE
Expose user management link for super admins

### DIFF
--- a/panel/views/partials/layout.ejs
+++ b/panel/views/partials/layout.ejs
@@ -15,6 +15,7 @@
         <% if (currentUser.role === 'SUPER_ADMIN') { %>
           <a href="/super/dashboard">Dashboard</a>
           <a href="/super/tenants">Tenants</a>
+          <a href="/super/users">Usuarios</a>
         <% } else { %>
           <a href="/app/dashboard">Dashboard</a>
           <a href="/app/menus">Menús</a>


### PR DESCRIPTION
## Summary
- show Super Admin link to manage users in the panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883b3eb80f8833394f61b70085e085e