### PR TITLE
Hide Menús for viewer role

### DIFF
--- a/panel/views/partials/layout.ejs
+++ b/panel/views/partials/layout.ejs
@@ -18,7 +18,9 @@
           <a href="/super/users">Usuarios</a>
         <% } else { %>
           <a href="/app/dashboard">Dashboard</a>
-          <a href="/app/menus">Menús</a>
+          <% if (currentUser.role !== 'VIEWER') { %>
+            <a href="/app/menus">Menús</a>
+          <% } %>
         <% } %>
         <a href="/logout" style="float:right;">Logout (<%= currentUser.email %>)</a>
       <% } %>


### PR DESCRIPTION
## Summary
- show the Menús link only for non-VIEWER users

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883b8edd3c883339a30463b5ff93c8d