### PR TITLE
Allow VIEWER role access to menus list

### DIFF
--- a/panel/src/routes/app.js
+++ b/panel/src/routes/app.js
@@ -63,7 +63,7 @@ router.get("/dashboard", async (req, res) => {
   });
 });
 
-router.get("/menus", ensureRoles(["TENANT_ADMIN", "SUPER_ADMIN"]), async (req, res) => {
+router.get("/menus", async (req, res) => {
   const user = req.user;
   const tenant = user.tenantId ? await prisma.tenants.findUnique({ where: { id: user.tenantId } }) : null;
   if (!tenant && user.role !== "SUPER_ADMIN") return res.status(403).send("Forbidden");


### PR DESCRIPTION
## Summary
- relax role requirements on the GET `/menus` route
- retain admin-only restrictions on menu creation routes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883b8ef0cb4833394a96e20bab4052f