### PR TITLE
Add interaction history view

### DIFF
--- a/panel/views/app/history.ejs
+++ b/panel/views/app/history.ejs
@@ -1,0 +1,30 @@
+<h1>Historial <%= tenant ? ('- ' + tenant.name) : '' %></h1>
+
+<form method="GET" class="filters">
+  <label>Desde <input type="date" name="from" value="<%= from %>"/></label>
+  <label>Hasta <input type="date" name="to" value="<%= to %>"/></label>
+  <button class="btn" type="submit">Aplicar</button>
+</form>
+
+<table>
+  <thead>
+    <tr>
+      <th>Fecha</th>
+      <th>Usuario</th>
+      <th>Mensaje</th>
+      <th>Intent</th>
+      <th>Fallback</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% interactions.forEach(i => { %>
+      <tr>
+        <td><%= i.timestamp.toISOString().slice(0,19).replace('T',' ') %></td>
+        <td><%= i.username %></td>
+        <td><%= i.message %></td>
+        <td><%= i.intent || '' %></td>
+        <td><%= i.isFallback ? 'Sí' : '' %></td>
+      </tr>
+    <% }) %>
+  </tbody>
+</table>

--- a/panel/views/partials/layout.ejs
+++ b/panel/views/partials/layout.ejs
@@ -18,6 +18,9 @@
           <a href="/super/users">Usuarios</a>
         <% } else { %>
           <a href="/app/dashboard">Dashboard</a>
+          <% if (currentUser.role === 'VIEWER') { %>
+            <a href="/app/history">Historial</a>
+          <% } %>
           <a href="/app/menus">Menús</a>
         <% } %>
         <a href="/logout" style="float:right;">Logout (<%= currentUser.email %>)</a>


### PR DESCRIPTION
## Summary
- add `/history` endpoint in panel to view recent interactions
- create `app/history.ejs` for the page
- show link to this page when user role is VIEWER

## Testing
- `npm run test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883b8f08b6c83339a16f383f18ca160