### PR TITLE
Restrict viewer access to new menu form

### DIFF
--- a/panel/views/app/menus.ejs
+++ b/panel/views/app/menus.ejs
@@ -1,6 +1,8 @@
 <h1>Menús <%= tenant ? ('- ' + tenant.name) : '' %></h1>
 
-<a href="/app/menus/new" class="btn">+ Nueva opción</a>
+<% if (currentUser.role !== 'VIEWER') { %>
+  <a href="/app/menus/new" class="btn">+ Nueva opción</a>
+<% } %>
 
 <table>
   <thead>


### PR DESCRIPTION
## Summary
- prevent users with the `VIEWER` role from seeing the *Nueva opción* button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6883b8efd3b08333afe6531f5766d30a