### PR TITLE
Enable custom usernames in bot UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ El panel agrega métricas diariamente a `metricsdaily` con node-cron.
 ## Bot UI
 
 - URL: http://localhost:8084
-- Elige un tenant y un usuario desde los desplegables y guarda la configuración. Luego envía `menu`.
+ - Elige un tenant y escribe o selecciona un usuario desde el campo con sugerencias, luego guarda la configuración y envía `menu`.
 - El servicio `bot-ui` usa la variable `DATABASE_URL` para conectarse a MySQL (por defecto `mysql://rasa:rasa123@mysql:3306/rasa`).
 
 ## Gateway

--- a/bot-ui/src/public/index.html
+++ b/bot-ui/src/public/index.html
@@ -36,7 +36,8 @@
           <select id="tenant"></select>
         </label>
         <label>Usuario
-          <select id="sender" disabled></select>
+          <input id="sender" list="senderList" />
+          <datalist id="senderList"></datalist>
         </label>
         <button id="saveCfg">Guardar</button>
       </div>
@@ -60,6 +61,7 @@
     const input = document.getElementById('message');
     const tenantInput = document.getElementById('tenant');
     const senderInput = document.getElementById('sender');
+    const senderList = document.getElementById('senderList');
     const saveCfgBtn = document.getElementById('saveCfg');
 
     const state = {
@@ -93,20 +95,16 @@
     }
 
     async function loadUsers(slug) {
-      senderInput.innerHTML = '';
-      senderInput.disabled = true;
+      senderList.innerHTML = '';
       if (!slug) return;
       try {
         const res = await fetch('/api/users?tenant=' + encodeURIComponent(slug));
         const arr = await res.json();
-        senderInput.innerHTML = '<option value="">Selecciona...</option>';
         arr.forEach(u => {
           const opt = document.createElement('option');
           opt.value = u;
-          opt.textContent = u;
-          senderInput.appendChild(opt);
+          senderList.appendChild(opt);
         });
-        senderInput.disabled = false;
         if (state.sender) senderInput.value = state.sender;
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- allow entering new usernames in the Bot UI
- update instructions about choosing usernames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883d93ebd048333888d6f1274df07db