### PR TITLE
Allow typing usernames in Bot UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ El panel agrega métricas diariamente a `metricsdaily` con node-cron.
 ## Bot UI
 
 - URL: http://localhost:8084
-- Elige un tenant y un usuario desde los desplegables y guarda la configuración. Luego envía `menu`.
+- Elige un tenant y escribe o selecciona un usuario en el campo correspondiente. Guarda la configuración y luego envía `menu`.
 - El servicio `bot-ui` usa la variable `DATABASE_URL` para conectarse a MySQL (por defecto `mysql://rasa:rasa123@mysql:3306/rasa`).
 
 ## Gateway

--- a/bot-ui/src/public/index.html
+++ b/bot-ui/src/public/index.html
@@ -36,7 +36,8 @@
           <select id="tenant"></select>
         </label>
         <label>Usuario
-          <select id="sender" disabled></select>
+          <input id="sender" list="senderList" autocomplete="off" />
+          <datalist id="senderList"></datalist>
         </label>
         <button id="saveCfg">Guardar</button>
       </div>
@@ -60,6 +61,7 @@
     const input = document.getElementById('message');
     const tenantInput = document.getElementById('tenant');
     const senderInput = document.getElementById('sender');
+    const senderList = document.getElementById('senderList');
     const saveCfgBtn = document.getElementById('saveCfg');
 
     const state = {
@@ -93,20 +95,16 @@
     }
 
     async function loadUsers(slug) {
-      senderInput.innerHTML = '';
-      senderInput.disabled = true;
+      senderList.innerHTML = '';
       if (!slug) return;
       try {
         const res = await fetch('/api/users?tenant=' + encodeURIComponent(slug));
         const arr = await res.json();
-        senderInput.innerHTML = '<option value="">Selecciona...</option>';
         arr.forEach(u => {
           const opt = document.createElement('option');
           opt.value = u;
-          opt.textContent = u;
-          senderInput.appendChild(opt);
+          senderList.appendChild(opt);
         });
-        senderInput.disabled = false;
         if (state.sender) senderInput.value = state.sender;
       } catch (err) {
         console.error(err);
@@ -119,7 +117,12 @@
       localStorage.setItem('tenant', state.tenant);
       localStorage.removeItem('sender');
       senderInput.value = '';
+      senderList.innerHTML = '';
       loadUsers(state.tenant);
+    });
+
+    senderInput.addEventListener('input', () => {
+      state.sender = senderInput.value;
     });
 
     function addMsg(author, text) {
@@ -148,7 +151,7 @@
       e.preventDefault();
       const text = input.value.trim();
       if (!text) return;
-      if (!tenantInput.value || !senderInput.value) {
+      if (!tenantInput.value || !state.sender) {
         addMsg('sistema', 'Debes configurar tenant y usuario primero.');
         return;
       }
@@ -162,7 +165,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             tenant: tenantInput.value,
-            sender: senderInput.value,
+            sender: state.sender,
             message: text
           })
         });


### PR DESCRIPTION
## Summary
- switch user selection to an input+datalist
- load usernames into datalist but allow any text
- store/update sender from the input and use it when sending messages
- document how to type a new username in the Bot UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883d96f608083338963ad9f5ce84c69