### PR TITLE
Add tenant training trigger

### DIFF
--- a/panel/views/super/tenant_dashboard.ejs
+++ b/panel/views/super/tenant_dashboard.ejs
@@ -1,4 +1,7 @@
 <h1>Dashboard Tenant: <%= tenant.name %></h1>
+<form method="POST" action="/super/tenants/<%= tenant.id %>/train" style="margin-bottom:10px;">
+  <button class="btn" type="submit">Entrenar bot</button>
+</form>
 
 <form method="GET" class="filters">
   <label>Desde <input type="date" name="from" value="<%= from %>"/></label>

--- a/panel/views/super/tenants.ejs
+++ b/panel/views/super/tenants.ejs
@@ -23,6 +23,9 @@
       <td><%= t.bots.length %></td>
       <td>
         <a class="btn" href="/super/tenants/<%= t.id %>/dashboard">Dashboard</a>
+        <form method="POST" action="/super/tenants/<%= t.id %>/train" style="display:inline;">
+          <button class="btn" type="submit">Entrenar</button>
+        </form>
       </td>
     </tr>
   <% }) %>


### PR DESCRIPTION
## Summary
- add endpoint to trigger Rasa training for a tenant
- expose button to start training from tenant dashboard and list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883d963e8c4833386ba14202ae28b87