### PR TITLE
Switch to Supabase and remove local mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-# Full Chatbot.com-like MVP (Rasa + Gateway + MySQL + Panel + Bot UI)
+# Full Chatbot.com-like MVP (Rasa + Gateway + Supabase + Panel + Bot UI)
 
 ## Servicios
 
-- **mysql**: base de datos
-- **rasa**: motor NLU/Core con tracker_store en MySQL
+- **supabase**: base de datos gestionada externamente
+- **rasa**: motor NLU/Core con tracker_store en Supabase
 - **action-server**: acciones custom (multi-tenant) + logging a archivo y DB
 - **gateway**: Flask que reescribe `sender -> tenant__user`
 - **panel**: Express + EJS con roles (SUPER_ADMIN, TENANT_ADMIN, ...) y dashboards
 - **bot-ui**: página simple para que los usuarios hablen con el bot
+
+### Supabase
+Este proyecto utiliza una base de datos gestionada en Supabase. Crea el proyecto en
+[supabase.com](https://supabase.com), obtén la cadena de conexión y defínela en la
+variable de entorno `SUPABASE_DB_URL` antes de levantar los servicios.
 
 ## Levantar todo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,6 @@
 version: "3.9"
 
 services:
-  mysql:
-    image: mysql:8
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: rasa
-      MYSQL_USER: rasa
-      MYSQL_PASSWORD: rasa123
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - mysql_data:/var/lib/mysql
 
   rasa:
     build:
@@ -27,10 +14,10 @@ services:
       - ./rasa:/app
       - ./logs:/logs
     depends_on:
-      - mysql
       - action-server
     environment:
       - PYTHONPATH=/app
+      - SUPABASE_DB_URL=${SUPABASE_DB_URL}
 
   action-server:
     build:
@@ -41,8 +28,8 @@ services:
     volumes:
       - ./rasa/actions:/app/actions
       - ./logs:/logs
-    depends_on:
-      - mysql
+    environment:
+      - SUPABASE_DB_URL=${SUPABASE_DB_URL}
 
   gateway:
     build: ./gateway
@@ -54,15 +41,14 @@ services:
   panel:
     build: ./panel
     environment:
-      DATABASE_URL: "mysql://rasa:rasa123@mysql:3306/rasa"
+      DATABASE_URL: "${SUPABASE_DB_URL}"
+      SUPABASE_DB_URL: "${SUPABASE_DB_URL}"
       SESSION_SECRET: "supersecret_session_key_change_me"
       PORT: "8090"
       SUPER_EMAIL: "owner@saas.com"
       SUPER_PASSWORD: "super123"
     ports:
       - "8090:8090"
-    depends_on:
-      - mysql
 
   bot-ui:
     build: ./bot-ui
@@ -74,5 +60,3 @@ services:
     depends_on:
       - gateway
 
-volumes:
-  mysql_data:


### PR DESCRIPTION
## Summary
- drop the `mysql` service from compose and remove its volume
- update dependent services to use an external Supabase URL via `SUPABASE_DB_URL`
- document Supabase requirements in the README

## Testing
- `npm test` *(fails: Missing script)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850e1fc1b88333a69a5726ebd6b677