### PR TITLE
Configure Rasa tracker store for Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@
 
 ### Supabase
 Este proyecto utiliza una base de datos gestionada en Supabase. Crea el proyecto en
-[supabase.com](https://supabase.com), obtén la cadena de conexión y defínela en la variable de entorno `SUPABASE_DB_URL` antes de levantar los servicios. Tanto Rasa como el servidor de acciones usarán esa URL para conectarse a la base de datos PostgreSQL.
+
+[supabase.com](https://supabase.com), obtén la cadena de conexión y defínela en la variable de entorno `SUPABASE_DB_URL` antes de levantar los servicios. Asegúrate de que tenga el prefijo `postgresql+psycopg2://`. Tanto Rasa como el servidor de acciones usarán esa URL para conectarse a la base de datos PostgreSQL. La imagen `rasa` ya incluye el driver `psycopg2-binary` (ver `rasa/Dockerfile`).
+
+Si es la primera vez que usas Supabase, crea las tablas del tracker store ejecutando:
+
+```bash
+docker compose run --rm rasa rasa db migrate
+```
 
 ```bash
 cd panel

--- a/rasa/endpoints.yml
+++ b/rasa/endpoints.yml
@@ -3,6 +3,8 @@ action_endpoint:
 
 tracker_store:
   type: SQL
-  engine_url: "mysql+pymysql://rasa:rasa123@mysql:3306/rasa?charset=utf8mb4"
+  # Cadena de conexión a Supabase en formato
+  # postgresql+psycopg2://user:password@host:port/db
+  engine_url: "${SUPABASE_DB_URL}"
   pool_size: 50
   pool_recycle: 3600


### PR DESCRIPTION
## Summary
- switch tracker store engine URL to use Supabase connection string
- document Postgres driver and DB migration steps in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851342bda483338fc685fdb2f16584