### PR TITLE
Add Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,19 @@ Una vez que Rasa entrenó, estará en `:5005`. El panel en `:8090`. El bot-UI en
 ### Cron de métricas
 El panel agrega métricas diariamente a `metricsdaily` con node-cron.
 
-## Bot UI
+## Frontend
 
 - URL: http://localhost:8084
-- Configura un tenant (ej `empresa1`) y un user (ej `user1`) y envía `menu`.
+- Aplicación Next.js con Tailwind y Shadcn UI. Configura un tenant (ej `empresa1`) y un user (ej `user1`) y envía `menu`.
+
+### Construir manualmente
+
+```bash
+cd frontend
+npm install
+npm run build
+npm start
+```
 
 ## Gateway
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
     ports:
       - "8090:8090"
 
-  bot-ui:
-    build: ./bot-ui
+  frontend:
+    build: ./frontend
     environment:
       PORT: "8084"
       GATEWAY_URL: "http://gateway:8000"

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+GATEWAY_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-bullseye-slim
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install && npm cache clean --force
+COPY . .
+RUN npm run build
+ENV PORT=8084
+EXPOSE 8084
+CMD ["npm","start"]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+}
+export default nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.6",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.2.2",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "class-variance-authority": "0.7.0",
+    "clsx": "1.2.1",
+    "tailwind-merge": "2.2.3",
+    "tailwindcss-animate": "1.0.7"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/app/api/message/route.ts
+++ b/frontend/src/app/api/message/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+const GATEWAY_URL = process.env.GATEWAY_URL || 'http://localhost:8000'
+
+export async function POST(req: Request) {
+  try {
+    const { tenant, sender, message } = await req.json()
+    if (!tenant || !sender || !message) {
+      return NextResponse.json({ error: 'tenant, sender and message are required' }, { status: 400 })
+    }
+    const url = `${GATEWAY_URL}/webhook/${encodeURIComponent(tenant)}`
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sender, message }),
+    })
+    const text = await resp.text()
+    let data
+    try { data = JSON.parse(text) } catch { data = text }
+    return NextResponse.json({ ok: resp.ok, status: resp.status, data }, { status: 200 })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'unknown error' }, { status: 500 })
+  }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css'
+import { Inter } from 'next/font/google'
+import type { Metadata } from 'next'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: 'Chatbot UI',
+  description: 'Multi-tenant chatbot frontend',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface ChatMessage { author: string; text: string }
+
+export default function Home() {
+  const [tenant, setTenant] = useState('')
+  const [sender, setSender] = useState('')
+  const [message, setMessage] = useState('')
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+
+  async function sendMessage() {
+    if (!message) return
+    setMessages(m => [...m, { author: 'me', text: message }])
+    const payload = { tenant, sender, message }
+    setMessage('')
+    try {
+      const res = await fetch('/api/message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const json = await res.json()
+      if (json.ok && Array.isArray(json.data)) {
+        const bots = json.data.filter((r: any) => r.text).map((r: any) => ({ author: 'bot', text: r.text }))
+        setMessages(m => [...m, ...bots])
+      } else {
+        setMessages(m => [...m, { author: 'system', text: 'Error: ' + JSON.stringify(json) }])
+      }
+    } catch (err: any) {
+      setMessages(m => [...m, { author: 'system', text: err.message }])
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4 max-w-2xl mx-auto">
+      <h1 className="text-xl font-bold">Chatbot Multi-Tenant</h1>
+      <div className="flex space-x-2">
+        <input value={tenant} onChange={e=>setTenant(e.target.value)} placeholder="tenant" className="border p-1 flex-1" />
+        <input value={sender} onChange={e=>setSender(e.target.value)} placeholder="sender" className="border p-1 flex-1" />
+      </div>
+      <div className="space-y-1 min-h-[300px] border p-2">
+        {messages.map((m,i)=> (
+          <div key={i} className={`text-sm ${m.author==='me' ? 'text-right' : ''}`}>
+            <span className="font-semibold mr-1">{m.author}</span>{m.text}
+          </div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          value={message}
+          onChange={e=>setMessage(e.target.value)}
+          placeholder="message"
+          className="flex-1 border p-1"
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); sendMessage(); } }}
+        />
+        <Button onClick={sendMessage}>Send</Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'underline-offset-4 hover:underline text-primary',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, ...props }, ref) => {
+  return <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+})
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('tailwindcss-animate')],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create `frontend` directory with a basic Next.js app
- enable Tailwind CSS and provide a sample shadcn-style Button component
- add API route that forwards `/api/message` requests to the gateway
- replace the old `bot-ui` service in `docker-compose.yml` with the new Next.js frontend
- document how to build and run the frontend

## Testing
- `npm install` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68854213b7e48333bf40f75c05e81681