### PR TITLE
Remove MySQL and use Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ npx prisma generate
    npm run seed
    cd ..
    ```
-4. Levanta los servicios sin MySQL:
+4. Levanta los servicios:
    ```bash
    docker compose up -d
    ```
-   Este `docker-compose.yml` no define un servicio MySQL; toda la persistencia se realiza en Supabase.
+   Toda la persistencia se realiza en Supabase; no hay contenedor MySQL.
 
 5. Ejemplos de variables en archivos `.env`:
    ```env

--- a/full-chatbot-mvp/README.md
+++ b/full-chatbot-mvp/README.md
@@ -1,9 +1,9 @@
-# Full Chatbot.com-like MVP (Rasa + Gateway + MySQL + Panel + Bot UI)
+# Full Chatbot.com-like MVP (Rasa + Gateway + Supabase + Panel + Bot UI)
 
 ## Servicios
 
-- **mysql**: base de datos
-- **rasa**: motor NLU/Core con tracker_store en MySQL
+- **supabase**: base de datos gestionada externamente
+- **rasa**: motor NLU/Core con tracker_store en Supabase
 - **action-server**: acciones custom (multi-tenant) + logging a archivo y DB
 - **gateway**: Flask que reescribe `sender -> tenant__user`
 - **panel**: Express + EJS con roles (SUPER_ADMIN, TENANT_ADMIN, ...) y dashboards

--- a/full-chatbot-mvp/action-server/Dockerfile
+++ b/full-chatbot-mvp/action-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM rasa/rasa-sdk:3.6.0
 USER root
-RUN pip install --no-cache-dir pymysql cryptography
+RUN pip install --no-cache-dir psycopg2-binary cryptography
 USER 1001

--- a/full-chatbot-mvp/docker-compose.yml
+++ b/full-chatbot-mvp/docker-compose.yml
@@ -1,19 +1,6 @@
 version: "3.9"
 
 services:
-  mysql:
-    image: mysql:8
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: rasa
-      MYSQL_USER: rasa
-      MYSQL_PASSWORD: rasa123
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - mysql_data:/var/lib/mysql
 
   rasa:
     build:
@@ -27,7 +14,6 @@ services:
       - ./rasa:/app
       - ./logs:/logs
     depends_on:
-      - mysql
       - action-server
     environment:
       - PYTHONPATH=/app
@@ -41,8 +27,6 @@ services:
     volumes:
       - ./rasa/actions:/app/actions
       - ./logs:/logs
-    depends_on:
-      - mysql
 
   gateway:
     build: ./gateway
@@ -54,15 +38,13 @@ services:
   panel:
     build: ./panel
     environment:
-      DATABASE_URL: "mysql://rasa:rasa123@mysql:3306/rasa"
+      DATABASE_URL: ${SUPABASE_DB_URL}
       SESSION_SECRET: "supersecret_session_key_change_me"
       PORT: "8090"
       SUPER_EMAIL: "owner@saas.com"
       SUPER_PASSWORD: "super123"
     ports:
       - "8090:8090"
-    depends_on:
-      - mysql
 
   bot-ui:
     build: ./bot-ui
@@ -74,5 +56,3 @@ services:
     depends_on:
       - gateway
 
-volumes:
-  mysql_data:

--- a/full-chatbot-mvp/panel/.env
+++ b/full-chatbot-mvp/panel/.env
@@ -1,4 +1,5 @@
-DATABASE_URL="mysql://rasa:rasa123@mysql:3306/rasa"
+SUPABASE_DB_URL="postgresql+psycopg2://usuario:password@db.supabase.co:5432/postgres"
+DATABASE_URL=${SUPABASE_DB_URL}
 SESSION_SECRET="supersecret_session_key_change_me"
 PORT=8090
 SUPER_EMAIL="owner@saas.com"

--- a/full-chatbot-mvp/panel/prisma/schema.prisma
+++ b/full-chatbot-mvp/panel/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "mysql"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 

--- a/full-chatbot-mvp/rasa/Dockerfile
+++ b/full-chatbot-mvp/rasa/Dockerfile
@@ -1,4 +1,4 @@
 FROM rasa/rasa:3.6.10
 USER root
-RUN pip install --no-cache-dir pymysql
+RUN pip install --no-cache-dir psycopg2-binary
 USER 1001

--- a/full-chatbot-mvp/rasa/actions/actions.py
+++ b/full-chatbot-mvp/rasa/actions/actions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-import pymysql
+import psycopg2
+import psycopg2.extras
 import logging
 from typing import Any, Text, Dict, List
 from rasa_sdk import Action, Tracker
@@ -16,22 +17,17 @@ handler.setFormatter(formatter)
 logger.setLevel(logging.INFO)
 logger.addHandler(handler)
 
-MYSQL_HOST = "mysql"
-MYSQL_USER = "rasa"
-MYSQL_PASSWORD = "rasa123"
-MYSQL_DB = "rasa"
+
+DB_URL = os.getenv("SUPABASE_DB_URL", "").replace("+psycopg2", "")
+
+def get_connection():
+    return psycopg2.connect(DB_URL, cursor_factory=psycopg2.extras.DictCursor)
 
 
 def log_interaction(tenant: str, username: str, menu_option: str, message: str, response: str) -> None:
     logger.info(f"{tenant} | {username} | {menu_option} | {message} | {response}")
     try:
-        connection = pymysql.connect(
-            host=MYSQL_HOST,
-            user=MYSQL_USER,
-            password=MYSQL_PASSWORD,
-            db=MYSQL_DB,
-            cursorclass=pymysql.cursors.DictCursor,
-        )
+        connection = get_connection()
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -62,13 +58,7 @@ class ActionShowMenu(Action):
             tenant, username = "default", sender_id
 
         try:
-            connection = pymysql.connect(
-                host=MYSQL_HOST,
-                user=MYSQL_USER,
-                password=MYSQL_PASSWORD,
-                db=MYSQL_DB,
-                cursorclass=pymysql.cursors.DictCursor,
-            )
+            connection = get_connection()
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
@@ -124,13 +114,7 @@ class ActionRespondMenuOption(Action):
         response_text = ""
         if menu_num:
             try:
-                connection = pymysql.connect(
-                    host=MYSQL_HOST,
-                    user=MYSQL_USER,
-                    password=MYSQL_PASSWORD,
-                    db=MYSQL_DB,
-                    cursorclass=pymysql.cursors.DictCursor,
-                )
+                connection = get_connection()
                 with connection.cursor() as cursor:
                     cursor.execute(
                         """

--- a/full-chatbot-mvp/rasa/endpoints.yml
+++ b/full-chatbot-mvp/rasa/endpoints.yml
@@ -3,6 +3,6 @@ action_endpoint:
 
 tracker_store:
   type: SQL
-  engine_url: "mysql+pymysql://rasa:rasa123@mysql:3306/rasa?charset=utf8mb4"
+  engine_url: ${SUPABASE_DB_URL}
   pool_size: 50
   pool_recycle: 3600


### PR DESCRIPTION
## Summary
- drop MySQL service from compose and use `SUPABASE_DB_URL`
- switch Prisma datasource to PostgreSQL
- update example env for panel and Rasa
- swap to psycopg2 in Dockerfiles and actions
- refresh docs to mention Supabase

## Testing
- `npx prisma migrate dev --name init` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6887a276fb4c83339a99b587f2203183