### PR TITLE
Add Next.js frontend skeleton

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend
+
+This directory contains a minimal Next.js 14 application configured with Tailwind CSS and Shadcn UI components. Lucide icons are used together with native emojis.
+
+The global chat state is managed using a React Context (`ChatContext`) which persists messages to `localStorage`. Messages are sent to the existing backend endpoint `/api/message` and panel routes can be accessed via helper functions in `src/lib/panel.ts`.
+
+Run `npm run dev` inside this folder to start the development server once dependencies are installed.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "latest"
+    "class-variance-authority": "latest",
+    "clsx": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.12",
+    "@types/node": "20.11.18",
+    "autoprefixer": "latest",
+    "postcss": "latest",
+    "tailwind-merge": "latest"
+    "tailwindcss": "latest"
+  }
+}
+

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import './globals.css'
+import { ChatProvider } from '../context/ChatContext'
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: 'Chatbot',
+  description: 'Multibot Frontend'
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <ChatProvider>
+          {children}
+        </ChatProvider>
+      </body>
+    </html>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,12 @@
+import Chat from '../components/Chat'
+
+export default function Home() {
+  return (
+    <main className="container mx-auto max-w-xl p-4">
+      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+        🤖 Multibot Chat
+      </h1>
+      <Chat />
+    </main>
+  )
+}

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+import { Send } from 'lucide-react'
+import { useChat } from '../context/ChatContext'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+
+export default function Chat() {
+  const { messages, sendMessage } = useChat()
+  const [text, setText] = useState('')
+
+  const handleSend = async () => {
+    if (!text.trim()) return
+    await sendMessage(text)
+    setText('')
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="border rounded p-4 h-64 overflow-y-auto bg-white">
+        {messages.map((m, i) => (
+          <div key={i} className="mb-2">
+            <span>{m.from === 'user' ? '🧑' : '🤖'} {m.text}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') handleSend() }}
+          placeholder="Escribe un mensaje..."
+        />
+        <Button onClick={handleSend} variant="default" size="icon">
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,30 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-700',
+        outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground'
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+)
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
+
+export const Button = ({ className, variant, size, ...props }: ButtonProps) => (
+  <button className={cn(buttonVariants({ variant, size, className }))} {...props} />
+)
+
+export { buttonVariants }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+interface ChatMessage {
+  from: 'user' | 'bot'
+  text: string
+}
+
+interface ChatState {
+  messages: ChatMessage[]
+  sendMessage: (text: string) => Promise<void>
+}
+
+const ChatContext = createContext<ChatState | undefined>(undefined)
+
+export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('chat')
+    if (stored) {
+      try {
+        setMessages(JSON.parse(stored))
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('chat', JSON.stringify(messages))
+  }, [messages])
+
+  const sendMessage = async (text: string) => {
+    setMessages(prev => [...prev, { from: 'user', text }])
+    try {
+      const res = await fetch('/api/message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tenant: 'default', sender: 'anonymous', message: text })
+      })
+      const data = await res.json()
+      const replies: string[] = Array.isArray(data.data)
+        ? data.data.map((r: any) => r.text)
+        : [data.data?.text || data.data]
+      replies.forEach(t => setMessages(prev => [...prev, { from: 'bot', text: t }]))
+    } catch (err) {
+      setMessages(prev => [...prev, { from: 'bot', text: 'Error sending message' }])
+    }
+  }
+
+  return (
+    <ChatContext.Provider value={{ messages, sendMessage }}>
+      {children}
+    </ChatContext.Provider>
+  )
+}
+
+export const useChat = () => {
+  const ctx = useContext(ChatContext)
+  if (!ctx) throw new Error('useChat must be used within ChatProvider')
+  return ctx
+}

--- a/frontend/src/lib/panel.ts
+++ b/frontend/src/lib/panel.ts
@@ -1,0 +1,7 @@
+export async function fetchDashboard(from?: string, to?: string) {
+  const params = new URLSearchParams()
+  if (from) params.set('from', from)
+  if (to) params.set('to', to)
+  const res = await fetch(`/app/dashboard?${params.toString()}`)
+  return res.text()
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: [
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 project in `frontend/`
- set up Tailwind CSS and sample Shadcn UI components
- create a global Chat context that persists to localStorage
- add basic chat UI using Lucide icons and emojis
- include helper to call panel dashboard endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887bbe4c6bc83338b40c2953e1c6f9e