### PR TITLE
Implement local auth context for frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "lucide-react": "latest"
+    "lucide-react": "latest",
     "class-variance-authority": "latest",
     "clsx": "latest"
   },
@@ -21,7 +21,7 @@
     "@types/node": "20.11.18",
     "autoprefixer": "latest",
     "postcss": "latest",
-    "tailwind-merge": "latest"
+    "tailwind-merge": "latest",
     "tailwindcss": "latest"
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import { ChatProvider } from '../context/ChatContext'
+import { AuthProvider } from '../context/AuthContext'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 
@@ -14,9 +15,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={inter.className}>
-        <ChatProvider>
-          {children}
-        </ChatProvider>
+        <AuthProvider>
+          <ChatProvider>
+            {children}
+          </ChatProvider>
+        </AuthProvider>
       </body>
     </html>
   )

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '../../context/AuthContext'
+import { Input } from '../../components/ui/input'
+import { Button } from '../../components/ui/button'
+import type { Role } from '../../types/role'
+
+const roles: Role[] = ['SUPER_ADMIN', 'TENANT_ADMIN', 'ANALYST', 'AGENT', 'VIEWER']
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [role, setRole] = useState<Role>('VIEWER')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    login({ email, role, token: password })
+    router.push('/')
+  }
+
+  return (
+    <main className="container mx-auto max-w-sm p-4">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <select
+          className="border rounded w-full p-2"
+          value={role}
+          onChange={e => setRole(e.target.value as Role)}
+        >
+          {roles.map(r => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+      </form>
+    </main>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,18 @@
 import Chat from '../components/Chat'
+import LogoutButton from '../components/LogoutButton'
+import Link from 'next/link'
+import { useAuth } from '../context/AuthContext'
 
 export default function Home() {
+  const { user } = useAuth()
   return (
-    <main className="container mx-auto max-w-xl p-4">
-      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
-        🤖 Multibot Chat
-      </h1>
+    <main className="container mx-auto max-w-xl p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          🤖 Multibot Chat
+        </h1>
+        {user ? <LogoutButton /> : <Link href="/login">Login</Link>}
+      </div>
       <Chat />
     </main>
   )

--- a/frontend/src/components/LogoutButton.tsx
+++ b/frontend/src/components/LogoutButton.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useAuth } from '../context/AuthContext'
+import { Button } from './ui/button'
+
+export default function LogoutButton() {
+  const { logout } = useAuth()
+  const router = useRouter()
+  return (
+    <Button
+      onClick={() => {
+        logout()
+        router.push('/login')
+      }}
+    >
+      Logout
+    </Button>
+  )
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import type { Role } from '../types/role'
+
+export interface AuthUser {
+  email: string
+  role: Role
+  token?: string
+}
+
+interface AuthState {
+  user: AuthUser | null
+  login: (info: AuthUser) => void
+  logout: () => void
+  hasRole: (role: Role | Role[]) => boolean
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null)
+
+  useEffect(() => {
+    const raw = localStorage.getItem('auth')
+    if (raw) {
+      try {
+        setUser(JSON.parse(raw))
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (user) localStorage.setItem('auth', JSON.stringify(user))
+    else localStorage.removeItem('auth')
+  }, [user])
+
+  const login = (info: AuthUser) => {
+    setUser(info)
+  }
+
+  const logout = () => {
+    setUser(null)
+  }
+
+  const hasRole = (roles: Role | Role[]) => {
+    if (!user) return false
+    const arr = Array.isArray(roles) ? roles : [roles]
+    return arr.includes(user.role)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, hasRole }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/frontend/src/types/role.ts
+++ b/frontend/src/types/role.ts
@@ -1,0 +1,6 @@
+export type Role =
+  | 'SUPER_ADMIN'
+  | 'TENANT_ADMIN'
+  | 'ANALYST'
+  | 'AGENT'
+  | 'VIEWER'


### PR DESCRIPTION
## Summary
- implement `AuthContext` with login/logout and role checks
- support new login page and logout button
- wrap layout with `AuthProvider`
- sync roles with panel's prisma enum via shared type

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887be050d74833386c52b70fd932ef5