### PR TITLE
Add basic Next.js 14 starter with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Full Chat Rasa Frontend
+
+Este repositorio contiene un ejemplo mínimo para arrancar un proyecto **Next.js 14** con **TypeScript** y **Tailwind CSS** que utiliza Supabase como base de datos. Incluye un contexto de autenticación que maneja los roles `SUPER_ADMIN`, `POWER_USER` y `USER` y guarda el estado en **LocalStorage**.
+
+## Características
+
+- Frontend con Next.js App Router y componentes en React.
+- Estilos con Tailwind CSS y componentes de Shadcn UI (pueden añadirse siguiendo la documentación oficial).
+- Autenticación mediante Supabase con jerarquía de roles y persistencia en LocalStorage.
+- Gestión de estado global con React Context.
+- Iconografía con Lucide React y emojis nativos.
+- Esquema SQL de ejemplo para Supabase en `supabase_schema.sql` que implementa un modelo multitenant y métricas diarias por bot.
+
+## Uso
+
+1. Copia `.env.example` a `.env` y configura la URL y clave anónima de tu proyecto Supabase.
+2. Instala las dependencias:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+3. Abre `http://localhost:3000` para ver la aplicación de ejemplo.
+
+Este proyecto es una base sobre la cual puedes construir la lógica específica de chat con Rasa, añadir gráficos de uso y permitir la gestión de menús desde la interfaz de usuario.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,19 @@
+import './styles/globals.css';
+import React from 'react';
+import { AuthProvider } from '../context/AuthContext';
+
+export const metadata = {
+  title: 'Full Chat Rasa',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="es">
+      <body>
+        <AuthProvider>
+          {children}
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
+import { LogIn, LogOut } from 'lucide-react';
+
+export default function Home() {
+  const { user, login, logout } = useAuth();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 gap-4">
+      {user ? (
+        <>
+          <p className="text-xl">Hola, {user.email}</p>
+          <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={logout}>
+            <LogOut className="inline" /> Cerrar sesión
+          </button>
+        </>
+      ) : (
+        <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={() => login('demo@demo.com', 'password')}>
+          <LogIn className="inline" /> Iniciar sesión
+        </button>
+      )}
+    </main>
+  );
+}

--- a/frontend/app/styles/globals.css
+++ b/frontend/app/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,0 +1,60 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+interface User {
+  id: string;
+  email: string;
+  role: 'SUPER_ADMIN' | 'POWER_USER' | 'USER';
+}
+
+interface AuthContextProps {
+  user: User | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+let supabase: SupabaseClient | null = null;
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    if (!supabaseUrl || !supabaseKey) return;
+    supabase = createClient(supabaseUrl, supabaseKey);
+    const stored = localStorage.getItem('auth-user');
+    if (stored) setUser(JSON.parse(stored));
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    if (!supabase) return;
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error || !data.user) return;
+    const role = (data.user.user_metadata.role as User['role']) || 'USER';
+    const userData = { id: data.user.id, email: data.user.email!, role };
+    setUser(userData);
+    localStorage.setItem('auth-user', JSON.stringify(userData));
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem('auth-user');
+    supabase?.auth.signOut();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "full-chat-rasa-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.5",
+    "lucide-react": "0.316.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -1,0 +1,43 @@
+-- Schema for multi-tenant Rasa chat project
+
+create table tenants (
+  id uuid primary key default gen_random_uuid(),
+  name text not null
+);
+
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid references tenants(id) on delete cascade,
+  email text not null unique,
+  password_hash text not null,
+  role text not null check (role in ('SUPER_ADMIN', 'POWER_USER', 'USER')),
+  created_at timestamp with time zone default now()
+);
+
+create table bots (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid references tenants(id) on delete cascade,
+  name text not null
+);
+
+create table conversations (
+  id uuid primary key default gen_random_uuid(),
+  bot_id uuid references bots(id) on delete cascade,
+  user_id uuid references users(id) on delete set null,
+  started_at timestamp with time zone default now()
+);
+
+create table messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid references conversations(id) on delete cascade,
+  sender text not null,
+  content text not null,
+  created_at timestamp with time zone default now()
+);
+
+create table metrics_daily (
+  id uuid primary key default gen_random_uuid(),
+  bot_id uuid references bots(id) on delete cascade,
+  date date not null,
+  interactions integer not null
+);


### PR DESCRIPTION
## Summary
- add README explaining the new frontend
- create a Next.js + TypeScript starter in `frontend`
- include auth context using Supabase
- provide an example SQL schema for a multitenant Rasa chat app

## Testing
- `npm install` *(fails: registry unreachable)*
- `npm run build` *(fails: next not found since deps not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6887c2d71608833391fca64f21313758