### PR TITLE
Add Next.js multitenant frontend skeleton

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "multitenant-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@supabase/supabase-js": "^2.0.0",
+    "lucide-react": "^0.321.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  height: 100%;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import { Providers } from '../lib/providers';
+
+export const metadata = {
+  title: 'Multitenant Platform',
+  description: 'Demo multitenant front end',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es">
+      <body>
+        <Providers>
+          {children}
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import Login from '../components/Login';
+import Dashboard from '../components/Dashboard';
+import { useSession } from '../lib/session-context';
+
+export default function HomePage() {
+  const { role } = useSession();
+
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      {role ? <Dashboard /> : <Login />}
+    </main>
+  );
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useSession } from '../lib/session-context';
+
+export default function Dashboard() {
+  const { role, tenantId } = useSession();
+
+  if (!role) return <p>Por favor inicie sesión.</p>;
+
+  return (
+    <div className="space-y-2">
+      <p className="font-semibold">Rol: {role}</p>
+      <p>Tenant: {tenantId}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useState } from 'react';
+import { supabase, useSession } from '../lib/session-context';
+
+export default function Login() {
+  const { setRole, setTenant } = useSession();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (!error && data.user) {
+      // Fake role/tenant assignment; replace with real logic
+      setRole('client');
+      setTenant('default');
+    }
+  };
+
+  return (
+    <div className="flex flex-col space-y-2">
+      <input className="border p-2" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input className="border p-2" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button className="bg-blue-500 text-white p-2" onClick={handleLogin}>Login</button>
+    </div>
+  );
+}

--- a/frontend/src/lib/providers.tsx
+++ b/frontend/src/lib/providers.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { ReactNode } from 'react';
+import { SessionContextProvider } from './session-context';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <SessionContextProvider>
+      {children}
+    </SessionContextProvider>
+  );
+}

--- a/frontend/src/lib/session-context.tsx
+++ b/frontend/src/lib/session-context.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export type Role = 'superadmin' | 'admin' | 'superuser' | 'client';
+
+interface SessionState {
+  supabase: SupabaseClient;
+  role: Role | null;
+  tenantId: string | null;
+  setRole: (r: Role | null) => void;
+  setTenant: (id: string | null) => void;
+}
+
+const SessionContext = createContext<SessionState | undefined>(undefined);
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
+export function SessionContextProvider({ children }: { children: ReactNode }) {
+  const [role, setRole] = useState<Role | null>(null);
+  const [tenantId, setTenant] = useState<string | null>(null);
+
+  return (
+    <SessionContext.Provider value={{ supabase, role, tenantId, setRole, setTenant }}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('useSession must be within SessionContextProvider');
+  return ctx;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: [
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+} satisfies Config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js 14 project structure with TypeScript
- add Tailwind and supabase context setup
- provide Login and Dashboard components demonstrating role and tenant handling

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cd576acc833385d43d9dff499b1e