### PR TITLE
Initialize SaaS multitenant skeleton

### DIFF
--- a/app/dashboard/admin_empresa/page.tsx
+++ b/app/dashboard/admin_empresa/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+import protectRoute from '@/utils/protectRoute';
+
+function AdminEmpresaPage() {
+  return <h2 className="text-xl">Panel Admin Empresa 📂</h2>;
+}
+
+export default protectRoute(AdminEmpresaPage, ['admin_empresa']);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import protectRoute from '@/utils/protectRoute';
+import { useAuth } from '@/contexts/AuthContext';
+import LogoutButton from '@/components/LogoutButton';
+
+function Dashboard() {
+  const { user } = useAuth();
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Hola {user?.email} 👋</h1>
+      <p>Rol: {user?.rol}</p>
+      <LogoutButton />
+    </div>
+  );
+}
+
+export default protectRoute(Dashboard);

--- a/app/dashboard/superadmin/page.tsx
+++ b/app/dashboard/superadmin/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+import protectRoute from '@/utils/protectRoute';
+
+function SuperadminPage() {
+  return <h2 className="text-xl">Panel Superadmin 🛠</h2>;
+}
+
+export default protectRoute(SuperadminPage, ['superadmin']);

--- a/app/dashboard/usuario_empresa/page.tsx
+++ b/app/dashboard/usuario_empresa/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+import protectRoute from '@/utils/protectRoute';
+
+function UsuarioEmpresaPage() {
+  return <h2 className="text-xl">Panel Usuario Empresa 📄</h2>;
+}
+
+export default protectRoute(UsuarioEmpresaPage, ['usuario_empresa']);

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,43 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
+import Link from 'next/link';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+
+const inter = Inter({ subsets: ['latin'] });
+
+function Sidebar() {
+  const { user } = useAuth();
+  if (!user) return null;
+  return (
+    <aside className="w-48 bg-gray-100 h-screen p-4">
+      <nav className="flex flex-col space-y-2">
+        <Link href="/dashboard">🏠 Dashboard</Link>
+        {user.rol === 'superadmin' && (
+          <Link href="/dashboard/superadmin">🛠 Superadmin</Link>
+        )}
+        {user.rol === 'admin_empresa' && (
+          <Link href="/dashboard/admin_empresa">📂 Admin</Link>
+        )}
+        {user.rol === 'usuario_empresa' && (
+          <Link href="/dashboard/usuario_empresa">📄 Usuario</Link>
+        )}
+      </nav>
+    </aside>
+  );
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es">
+      <body className={inter.className}>
+        <AuthProvider>
+          <div className="flex">
+            <Sidebar />
+            <main className="flex-1 p-6">{children}</main>
+          </div>
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function LoginPage() {
+  const { signIn } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Completa todos los campos');
+      return;
+    }
+    const { error } = await signIn({ email, password });
+    if (error) {
+      setError('Credenciales incorrectas');
+      return;
+    }
+    router.push('/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <Card className="w-96">
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              type="email"
+            />
+            <Input
+              placeholder="Contraseña"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              type="password"
+            />
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <Button type="submit" className="w-full">🚀 Ingresar</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/login');
+}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function LogoutButton() {
+  const { signOut } = useAuth();
+  return (
+    <Button onClick={signOut} className="mt-4">🔓 Salir</Button>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={clsx(
+        'px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+
+export function Card({ className, children }: { className?: string; children: ReactNode }) {
+  return (
+    <div className={clsx('border rounded shadow-sm bg-white', className)}>{children}</div>
+  );
+}
+
+export function CardContent({ className, children }: { className?: string; children: ReactNode }) {
+  return <div className={clsx('p-4', className)}>{children}</div>;
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './button';
+export * from './input';
+export * from './card';

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,14 @@
+import { InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={clsx(
+        'w-full px-3 py-2 border rounded focus:outline-none focus:ring',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { User } from '@/types';
+
+interface SignInPayload {
+  email: string;
+  password: string;
+}
+
+interface AuthContextProps {
+  user: User | null;
+  loading: boolean;
+  signIn: (payload: SignInPayload) => Promise<{ error: any }>; 
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  loading: true,
+  signIn: async () => ({ error: null }),
+  signOut: async () => {}
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('auth');
+    if (saved) setUser(JSON.parse(saved));
+    setLoading(false);
+  }, []);
+
+  const signIn = async ({ email, password }: SignInPayload) => {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (data?.user) {
+      const { data: userData } = await supabase
+        .from('usuarios')
+        .select('id, email, rol, tenant_id')
+        .eq('id', data.user.id)
+        .single();
+      if (userData) {
+        setUser(userData);
+        localStorage.setItem('auth', JSON.stringify(userData));
+        await supabase.from('auditoria_usuarios').insert({
+          id_usuario: userData.id,
+          id_tenant: userData.tenant_id,
+          accion: 'login'
+        });
+      }
+    }
+    return { error };
+  };
+
+  const signOut = async () => {
+    if (user) {
+      await supabase.from('auditoria_usuarios').insert({
+        id_usuario: user.id,
+        id_tenant: user.tenant_id,
+        accion: 'logout'
+      });
+    }
+    await supabase.auth.signOut();
+    setUser(null);
+    localStorage.removeItem('auth');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "multitenant-saas",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "clsx": "1.2.1",
+    "lucide-react": "^0.272.0",
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.50.0",
+    "eslint-config-next": "14.0.0",
+    "postcss": "^8.4.26",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/supabase_init.sql
+++ b/supabase_init.sql
@@ -1,0 +1,47 @@
+-- Tabla tenants
+create table if not exists tenants (
+  id uuid primary key,
+  nombre text not null,
+  created_at timestamp default now()
+);
+
+-- Tabla usuarios
+create table if not exists usuarios (
+  id uuid primary key,
+  email text unique,
+  rol text check (rol in ('superadmin','admin_empresa','usuario_empresa')),
+  tenant_id uuid references tenants(id),
+  created_at timestamp default now()
+);
+
+-- Tabla auditoria_usuarios
+create table if not exists auditoria_usuarios (
+  id uuid primary key default gen_random_uuid(),
+  id_usuario uuid references usuarios(id),
+  id_tenant uuid references tenants(id),
+  accion text check (accion in ('login','logout')),
+  fecha timestamp default now()
+);
+
+-- Policies
+alter table usuarios enable row level security;
+create policy "usuario solo ve su tenant" on usuarios
+  for select using ( auth.uid() = id or exists (
+    select 1 from usuarios u where u.id = auth.uid() and u.rol = 'superadmin'
+  ));
+create policy "solo superadmin o admin de su tenant" on usuarios
+  for update using (
+    exists (select 1 from usuarios u where u.id = auth.uid() and (u.rol = 'superadmin' or (u.rol = 'admin_empresa' and u.tenant_id = usuarios.tenant_id)))
+  );
+
+alter table tenants enable row level security;
+create policy "superadmin ve todos los tenants" on tenants
+  for select using (exists (select 1 from usuarios u where u.id = auth.uid() and u.rol = 'superadmin'));
+create policy "admin y usuario ven su tenant" on tenants
+  for select using (exists (select 1 from usuarios u where u.id = auth.uid() and u.tenant_id = tenants.id));
+
+alter table auditoria_usuarios enable row level security;
+create policy "propios y superadmin" on auditoria_usuarios
+  for select using (
+    exists (select 1 from usuarios u where u.id = auth.uid() and (u.rol = 'superadmin' or u.id = auditoria_usuarios.id_usuario))
+  );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id: string;
+  email: string;
+  rol: 'superadmin' | 'admin_empresa' | 'usuario_empresa';
+  tenant_id: string;
+}

--- a/utils/protectRoute.tsx
+++ b/utils/protectRoute.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function protectRoute<T>(Component: React.ComponentType<T>, roles?: string[]) {
+  return function Protected(props: T) {
+    const { user, loading } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+      if (!loading) {
+        if (!user) {
+          router.replace('/login');
+        } else if (roles && !roles.includes(user.rol)) {
+          router.replace('/login');
+        }
+      }
+    }, [user, loading, router]);
+
+    if (!user) return null;
+    if (roles && !roles.includes(user.rol)) return null;
+    return <Component {...props} />;
+  };
+}


### PR DESCRIPTION
## Summary
- bootstrap Next.js 14 project structure with Tailwind
- add basic UI components using shadcn style
- implement auth context with Supabase and local storage
- create protected routes per role
- add login form and dashboards per user role
- include Supabase SQL schema with RLS policies

## Testing
- `npm install --silent` *(fails: network disabled)*
- `npm run build` *(fails: `next` not found due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_6887d46781108333b7783d9239af70ae