### PR TITLE
Insert 'use client' directive

### DIFF
--- a/utils/protectRoute.tsx
+++ b/utils/protectRoute.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';


### PR DESCRIPTION
## Summary
- add the React Server Component directive in `utils/protectRoute.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e7051a108333adef9133a3601443