### PR TITLE
Add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# URL y clave del proyecto Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://<your-project>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+
+# Prisma DB URL (usa la misma que Supabase si es PostgreSQL)
+DATABASE_URL=postgresql://postgres:password@db.<your-project>.supabase.co:5432/postgres

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 
 # Ignore environment files
 .env*
+!.env.example
 
 # Ignore zip archives
 *.zip

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm install js-cookie
 
 ### 3. Configurar variables de entorno
 
-Crea un archivo `.env.local`:
+Copia el archivo `.env.example` a `.env.local` y completa los valores:
 
 ```env
 NEXT_PUBLIC_SUPABASE_URL=https://<tu-proyecto>.supabase.co


### PR DESCRIPTION
## Summary
- add `.env.example` file
- allow committing the file
- reference `.env.example` in setup instructions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887eed0a24c833386466fb578c6b9d2