### PR TITLE
Add login page and redirect

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Completa todos los campos');
+      return;
+    }
+    const success = await login(email, password);
+    if (!success) {
+      setError('Credenciales incorrectas');
+      return;
+    }
+    router.push('/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="bg-white shadow-md rounded px-8 py-6 w-96">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+          <input
+            type="password"
+            placeholder="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            🚀 Ingresar
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/login');
+}


### PR DESCRIPTION
## Summary
- add a simple login page using `useAuth`
- redirect `/` to `/login`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ec2ba4e88333a411fe7f9a1724e7