### PR TITLE
Add API to create contexto

### DIFF
--- a/app/api/contextos/route.ts
+++ b/app/api/contextos/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  try {
+    const { nombre, contenido, tenantId } = await request.json()
+
+    if (!nombre || !contenido || !tenantId) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+    }
+
+    const contexto = await prisma.contexto.create({
+      data: { nombre, contenido, tenantId }
+    })
+
+    return NextResponse.json(contexto)
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json(
+      { error: 'Error creating contexto' },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- add Prisma client helper
- implement POST route under `app/api/contextos` for creating contextos

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888edc3a05c8333a2b70522b8f78cfd