### PR TITLE
Implement auth provider and guard

### DIFF
--- a/panel/app/dashboard/page.tsx
+++ b/panel/app/dashboard/page.tsx
@@ -1,1 +1,9 @@
-export default function Dashboard() { return <div>Dashboard</div>; }
+import RequireAuth from '@/components/RequireAuth';
+
+export default function Dashboard() {
+  return (
+    <RequireAuth>
+      <div>Dashboard</div>
+    </RequireAuth>
+  );
+}

--- a/panel/app/layout.tsx
+++ b/panel/app/layout.tsx
@@ -1,8 +1,12 @@
 
+import { AuthProvider } from '@/contexts/AuthContext';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es">
-      <body>{children}</body>
+      <body>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/panel/components/RequireAuth.tsx
+++ b/panel/components/RequireAuth.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace('/login');
+    }
+  }, [user, router]);
+
+  if (user === null) {
+    return null;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- wrap layout body with `AuthProvider`
- add `RequireAuth` component for redirecting to login
- protect the dashboard page with `RequireAuth`

## Testing
- `npm run lint` *(fails: `next` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68890ba54c2083339d2fa275ae44fd92