### PR TITLE
Add auth guard integration

### DIFF
--- a/panel/app/layout.tsx
+++ b/panel/app/layout.tsx
@@ -4,9 +4,9 @@ import { AuthProvider } from '@/contexts/AuthContext';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es">
-      <body>
-        <AuthProvider>{children}</AuthProvider>
-      </body>
+      <AuthProvider>
+        <body>{children}</body>
+      </AuthProvider>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `<body>` with `AuthProvider`
- ensure pages use `RequireAuth` to redirect to `/login`

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68890e75f50883338404135da9214fed