### PR TITLE
Add role-based dashboards

### DIFF
--- a/panel/app/dashboard/page.tsx
+++ b/panel/app/dashboard/page.tsx
@@ -1,9 +1,20 @@
+'use client';
 import RequireAuth from '@/components/RequireAuth';
+import { useAuth } from '@/contexts/AuthContext';
+import SuperAdminDashboard from '@/components/dashboards/SuperAdminDashboard';
+import TenantAdminDashboard from '@/components/dashboards/TenantAdminDashboard';
+import UserDashboard from '@/components/dashboards/UserDashboard';
 
 export default function Dashboard() {
+  const { role } = useAuth();
+
+  let Component = UserDashboard;
+  if (role === 'SUPER_ADMIN') Component = SuperAdminDashboard;
+  else if (role === 'TENANT_ADMIN') Component = TenantAdminDashboard;
+
   return (
     <RequireAuth>
-      <div>Dashboard</div>
+      <Component />
     </RequireAuth>
   );
 }

--- a/panel/components/dashboards/SuperAdminDashboard.tsx
+++ b/panel/components/dashboards/SuperAdminDashboard.tsx
@@ -1,0 +1,3 @@
+export default function SuperAdminDashboard() {
+  return <div>Super Admin Dashboard</div>;
+}

--- a/panel/components/dashboards/TenantAdminDashboard.tsx
+++ b/panel/components/dashboards/TenantAdminDashboard.tsx
@@ -1,0 +1,3 @@
+export default function TenantAdminDashboard() {
+  return <div>Tenant Admin Dashboard</div>;
+}

--- a/panel/components/dashboards/UserDashboard.tsx
+++ b/panel/components/dashboards/UserDashboard.tsx
@@ -1,0 +1,3 @@
+export default function UserDashboard() {
+  return <div>User Dashboard</div>;
+}

--- a/panel/contexts/AuthContext.tsx
+++ b/panel/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import { Usuario } from '@/types/auth';
 
 type AuthContextType = {
   user: Usuario | null;
+  role: string | null;
   login: (email: string, password: string) => Promise<{ success: boolean; message: string }>;
   logout: () => void;
 };
@@ -15,6 +16,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<Usuario | null>(null);
+  const [role, setRole] = useState<string | null>(null);
   const router = useRouter();
 
   const login = async (email: string, password: string) => {
@@ -41,6 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     setUser(data);
+    setRole(data.role);
     router.push('/dashboard');
     return { success: true, message: 'Login exitoso' };
   };
@@ -48,11 +51,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = async () => {
     await supabase.auth.signOut();
     setUser(null);
+    setRole(null);
     router.push('/login');
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, role, login, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- store user role in `AuthContext`
- add dashboard components for `SUPER_ADMIN`, `TENANT_ADMIN` and `USER`
- switch dashboard page based on logged in role

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_688910680eec83338d9b615a6b2f9100